### PR TITLE
Stop showing coordinates outside of spoilers

### DIFF
--- a/src/main/java/dev/zenith/pearlplus/command/PearlPlusCommand.java
+++ b/src/main/java/dev/zenith/pearlplus/command/PearlPlusCommand.java
@@ -119,7 +119,7 @@ public class PearlPlusCommand extends Command {
                                                     manager.recordPearl(uuid, name, pearlId, x, y, z);
                                                     c.getSource().getEmbed()
                                                             .title("Pearl stored for " + name)
-                                                            .description(String.format("%s at %d %d %d", pearlId, x, y, z));
+                                                            .description(String.format("%s at ||%d %d %d||", pearlId, x, y, z));
                                                     return 0;
                                                 })))))));
 

--- a/src/main/java/dev/zenith/pearlplus/module/AutoDetectModule.java
+++ b/src/main/java/dev/zenith/pearlplus/module/AutoDetectModule.java
@@ -311,7 +311,7 @@ public class AutoDetectModule extends Module {
                 .title("Pearl Registered")
                 .addField("Pearl", pearlId)
                 .addField("Owner", ownerSummary)
-                .addField("Position", String.format("%d %d %d", position.x(), position.y(), position.z()))
+                .addField("Position", String.format("||%d %d %d||", position.x(), position.y(), position.z()))
         );
     }
 
@@ -582,7 +582,7 @@ public class AutoDetectModule extends Module {
                 .title("Pearl Removal Warning")
                 .addField("Owner", trackedPearl.ownerSummary())
                 .addField("Pearl", trackedPearl.pearlId() == null ? "unknown" : trackedPearl.pearlId())
-                .addField("Position", String.format("%d %d %d", trackedPearl.blockX(), trackedPearl.blockY(), trackedPearl.blockZ()));
+                .addField("Position", String.format("||%d %d %d||", trackedPearl.blockX(), trackedPearl.blockY(), trackedPearl.blockZ()));
         discordAndIngameNotification(builder);
     }
 


### PR DESCRIPTION
self-explanatory bcuz we already have the spoiler formatting in listing pearl coords, so add it to auto-detect n shit